### PR TITLE
feat: 원하는 기간의 모든 레코드 읽어오기 추가 for pattern

### DIFF
--- a/src/main/java/com/harmonycare/domain/record/controller/RecordController.java
+++ b/src/main/java/com/harmonycare/domain/record/controller/RecordController.java
@@ -7,6 +7,7 @@ import com.harmonycare.domain.record.service.RecordService;
 import com.harmonycare.global.security.details.PrincipalDetails;
 import com.harmonycare.global.util.ApiUtil;
 import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -18,7 +19,10 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.time.LocalDate;
 import java.util.List;
 
 import static com.harmonycare.global.util.ApiUtil.success;
@@ -109,4 +113,26 @@ public class RecordController {
 
         return ResponseEntity.ok().body(success(HttpStatus.OK, recordReadResponses));
     }
+
+    /**
+     *  기간 내의 모든 기록 읽어오기
+     *
+     * @param principalDetails
+     * @param today 시작할 날짜
+     * @param duration 읽어오고 싶은 기간
+     * @return 기간 내의 모든 기록
+     */
+    @GetMapping()
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<ApiUtil.ApiSuccessResult<List<RecordReadResponse>>> readDuration(
+            @AuthenticationPrincipal PrincipalDetails principalDetails,
+            @RequestParam("date") @DateTimeFormat(pattern = "yyyy-mm-dd") LocalDate today,
+            @RequestParam("duration") Long duration
+    ) {
+        List<RecordReadResponse> recordReadResponses =
+                recordService.readDurationRecord(principalDetails.member(), today, duration);
+
+        return ResponseEntity.ok().body(success(HttpStatus.OK, recordReadResponses));
+    }
+
 }

--- a/src/main/java/com/harmonycare/domain/record/dto/request/RecordUpdateRequest.java
+++ b/src/main/java/com/harmonycare/domain/record/dto/request/RecordUpdateRequest.java
@@ -2,5 +2,5 @@ package com.harmonycare.domain.record.dto.request;
 
 import com.harmonycare.domain.record.entity.RecordTask;
 
-public record RecordUpdateRequest(RecordTask recordTask, String recordTime, String description) {
+public record RecordUpdateRequest(RecordTask recordTask, String recordTime, Long minute, String description) {
 }

--- a/src/main/java/com/harmonycare/domain/record/dto/response/RecordReadResponse.java
+++ b/src/main/java/com/harmonycare/domain/record/dto/response/RecordReadResponse.java
@@ -3,6 +3,15 @@ package com.harmonycare.domain.record.dto.response;
 import com.harmonycare.domain.record.entity.RecordTask;
 import lombok.Builder;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
 @Builder
-public record RecordReadResponse(RecordTask recordTask, String recordTime, String description) {
+public record RecordReadResponse(RecordTask recordTask, String recordTime, Long minute, String description)
+{
+    public static boolean isSameToday(LocalDate today, RecordReadResponse recordReadResponse) {
+        return LocalDateTime.parse(recordReadResponse.recordTime())
+                .toLocalDate().isEqual(today);
+    }
 }
+

--- a/src/main/java/com/harmonycare/domain/record/entity/Record.java
+++ b/src/main/java/com/harmonycare/domain/record/entity/Record.java
@@ -44,18 +44,21 @@ public class Record {
     @Column(name = "record_time")
     private LocalDateTime recordTime;
 
+    @Column(name = "minute")
+    private Long minute;
+
     @Column(name = "description")
     private String description;
 
     @Builder
-    public Record(Long id, Baby baby, RecordTask recordTask, LocalDateTime recordTime, String description) {
+    public Record(Long id, Baby baby, RecordTask recordTask, LocalDateTime recordTime, Long minute, String description) {
         this.id = id;
         this.baby = baby;
         this.recordTask = recordTask;
         this.recordTime = recordTime;
+        this.minute = minute;
         this.description = description;
     }
-
 
     public void update(RecordUpdateRequest request) {
 
@@ -65,6 +68,10 @@ public class Record {
 
         if (request.recordTime() != null) {
             this.recordTime = DateTimeUtil.stringToLocalDateTime(request.recordTime());
+        }
+
+        if (request.minute() != null) {
+            this.minute = request.minute();
         }
 
         if (request.description() != null) {


### PR DESCRIPTION
Pattern을 그리기위해서 설정한 기간내의 모든 레코드의 정보를 가져오는 로직을 추가했습니다

수정사항
1. recordTask(SLEEP, MEAL ... ) 들을 수행하는데 시간이 얼마나 걸리는지 저장하는게 없어서, DTO에 Long minute을 추가했습니다
예를 들어 minute을 20으로 주면 recordTask를 수행하는데 20분이 걸렸다는 기록입니다

2. recordTime의 데이터를 처음에 받아올 때, "recordTime": "2023-02-16 03:37:30"의 형식으로 받아왔었는데
"recordTime": "2023-02-16T03:37:30"의 형태로 중간에 T가 끼여있는 LocalDateTime의 기본 형식에 맞게 그냥 받아오는게 어떨까 싶습니다 !! entity에서도 recordTime이 LocalDateTime 타입이고, 기본 LocalDateTime의 메서드를 여러개 사용해야해서 일단은 그렇게 수정했습니다

EX) 서비스 로직에 CREATE 부분에서 
 LocalDateTime resultDateTime = DateTimeUtil.stringToLocalDateTime(request.recordTime()) ->
 LocalDateTime resultDateTime = LocalDateTime.parse(request.recordTime());

